### PR TITLE
update to gleam 0.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,6 @@ jobs:
           otp-version: 22.2
       - uses: gleam-lang/setup-gleam@v1.0.1
         with:
-          gleam-version: 0.10.1
+          gleam-version: 0.11.2
       - run: rebar3 install_deps
       - run: rebar3 eunit

--- a/rebar.config
+++ b/rebar.config
@@ -8,6 +8,6 @@
 {project_plugins, [rebar_gleam]}.
 
 {deps, [
-    {gleam_stdlib, "~> 0.10.1"},
+    {gleam_stdlib, "~> 0.11.0"},
     {gleam_http, "~> 1.3"}
 ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,8 +1,11 @@
-{"1.1.0",
-[{<<"gleam_http">>,{pkg,<<"gleam_http">>,<<"1.3.0">>},0},
+{"1.2.0",
+[{<<"gleam_http">>,{pkg,<<"gleam_http">>,<<"1.4.0">>},0},
  {<<"gleam_stdlib">>,{pkg,<<"gleam_stdlib">>,<<"0.10.1">>},0}]}.
 [
 {pkg_hash,[
- {<<"gleam_http">>, <<"DC84D787CB49550D7E98834A966A4F07EE90FE863A6088E752E8F1A208AB41C1">>},
- {<<"gleam_stdlib">>, <<"F123F33E03B5CDF5E19FC179B9EE81269DEB93F7DEFADB17EF2930E4DB9011E7">>}]}
+ {<<"gleam_http">>, <<"5A149037A298CCA365F2E447736D7B15F620E95C2028658EB3ADDBA05725DB08">>},
+ {<<"gleam_stdlib">>, <<"F123F33E03B5CDF5E19FC179B9EE81269DEB93F7DEFADB17EF2930E4DB9011E7">>}]},
+{pkg_hash_ext,[
+ {<<"gleam_http">>, <<"F1E1FDE4BBCF905CE0E9C1A867D56E05D8898945C8E10C247235A6D9623FF045">>},
+ {<<"gleam_stdlib">>, <<"8ACD5D8AE1BD013B848F22745BE39E6D25968BF29899A87EB5D7057F4ED89DD0">>}]}
 ].


### PR DESCRIPTION
Hello! I was attempting to use httpc with a project of mine running gleam 0.11.2 and gleam_stdlib 0.11.0. Currently, httpc depends on an older version of gleam_stdlib.

I've updated the rebar config to the latest gleam_stdlib and the tests pass. I figured I would open this PR as it seemed like this library missed the update to the latest version of gleam. 

If it was kept on the old version for a reason, feel free to close this PR.