### PR TITLE
Fix the readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ Bindings to Erlang's built in HTTP client, `httpc`.
 
 ```rust
 import gleam/httpc
-import gleam/http.{Get, Response}
+import gleam/http.{Get}
 import gleam/should
 
 pub fn main() {
   // Prepare a HTTP request record
-  let resp = http.default_req()
+  let req = http.default_req()
     |> http.set_method(Get)
     |> http.set_host("test-api.service.hmrc.gov.uk")
     |> http.set_path("/hello/world")


### PR DESCRIPTION
Fixes 2 issues in the README's example code:

Unknown variable
<img width="637" alt="Unknown variable" src="https://user-images.githubusercontent.com/645203/98443646-774c3180-2104-11eb-835f-035e5646d06b.png">

Unused constructor
<img width="630" alt="Unused constructor" src="https://user-images.githubusercontent.com/645203/98443639-71eee700-2104-11eb-92a1-76918b3eac8a.png">
