### PR TITLE
feat: Upgrade to Gleam http 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Upgraded `gleam_http` to v3.0.0. #25
+
 ## v1.1.0 - 2021-12-05
 
 - Converted to use the Gleam build tool.

--- a/gleam.toml
+++ b/gleam.toml
@@ -13,9 +13,9 @@ links = [
 extra_applications = ["inets", "ssl"]
 
 [dependencies]
-gleam_stdlib = "~> 0.18"
-gleam_http = "~> 2.0"
+gleam_stdlib = "~> 0.20"
+gleam_http = "~> 3.0"
 
 [dev-dependencies]
-gleeunit = "~> 0.1"
-gleam_erlang = "~> 0.4"
+gleeunit = "~> 0.6"
+gleam_erlang = "~> 0.9"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,14 +2,14 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_erlang", version = "0.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "67A456C0D3908050C869D19721BAE300C6C4ED41BFC034CC80DF7828EAB5E183" },
-  { name = "gleam_http", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "C2DF02A2BD551B590D92ADA90A67CDEE60EB4BAD48B5EE10A9AB4CE180CBCE36" },
-  { name = "gleam_stdlib", version = "0.18.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "2938F996BBB25D75E973226846CDDFA33AB5590AFC8A9D043A356EA85272510D" },
-  { name = "gleeunit", version = "0.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "E8FDD4E31E0BBB87F625B0BB4DEABDE780180F1C2B15A4534442823066468638" },
+  { name = "gleam_erlang", version = "0.9.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "15D0B66DA08D63C16EDDF32A70F6EB49E44DC83DB0370B7A45F1E954F8A23174" },
+  { name = "gleam_http", version = "3.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "FB65B42C7AF4C14F1DC0AD9A3ABCE50E9486D3F8D0A42C9E52A2B8BD651739DF" },
+  { name = "gleam_stdlib", version = "0.20.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "E5715F0CDCB3AB1BB73C6C35E46DA223997F680550E17CE46BC88B710E061CCE" },
+  { name = "gleeunit", version = "0.6.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "5BF486C3E135B7F5ED8C054925FC48E5B2C79016A39F416FD8CF2E860520EE55" },
 ]
 
 [requirements]
-gleam_erlang = "~> 0.4"
-gleam_http = "~> 2.0"
-gleam_stdlib = "~> 0.18"
-gleeunit = "~> 0.1"
+gleam_erlang = "~> 0.9"
+gleam_http = "~> 3.0"
+gleam_stdlib = "~> 0.20"
+gleeunit = "~> 0.6"

--- a/src/gleam/httpc.gleam
+++ b/src/gleam/httpc.gleam
@@ -1,5 +1,7 @@
 import gleam/dynamic.{Dynamic}
-import gleam/http.{Method, Request, Response}
+import gleam/http.{Method}
+import gleam/http/response.{Response}
+import gleam/http/request.{Request}
 import gleam/bit_string
 import gleam/result
 import gleam/list
@@ -62,7 +64,7 @@ pub fn send_bits(
 ) -> Result(Response(BitString), Dynamic) {
   let erl_url =
     req
-    |> http.req_to_uri
+    |> request.to_uri
     |> uri.to_string
     |> binary_to_list
   let erl_headers = list.map(req.headers, charlist_header)
@@ -77,7 +79,7 @@ pub fn send_bits(
     _ -> {
       let erl_content_type =
         req
-        |> http.get_req_header("content-type")
+        |> request.get_header("content-type")
         |> result.unwrap("application/octet-stream")
         |> binary_to_list
       let erl_req = #(erl_url, erl_headers, erl_content_type, req.body)
@@ -94,11 +96,11 @@ pub fn send_bits(
 pub fn send(req: Request(String)) -> Result(Response(String), Dynamic) {
   try resp =
     req
-    |> http.map_req_body(bit_string.from_string)
+    |> request.map(bit_string.from_string)
     |> send_bits
 
   case bit_string.to_string(resp.body) {
-    Ok(body) -> Ok(http.set_resp_body(resp, body))
+    Ok(body) -> Ok(response.set_body(resp, body))
     Error(_) -> Error(dynamic.from("Response body was not valid UTF-8"))
   }
 }

--- a/test/gleam_httpc_test.gleam
+++ b/test/gleam_httpc_test.gleam
@@ -1,5 +1,7 @@
 import gleam/httpc
 import gleam/http.{Get, Head, Options}
+import gleam/http/request
+import gleam/http/response
 import gleam/list
 import gleeunit
 import gleam/erlang
@@ -18,59 +20,59 @@ pub fn main() {
 
 pub fn request_test() {
   let req =
-    http.default_req()
-    |> http.set_method(Get)
-    |> http.set_host("test-api.service.hmrc.gov.uk")
-    |> http.set_path("/hello/world")
-    |> http.prepend_req_header("accept", "application/vnd.hmrc.1.0+json")
+    request.new()
+    |> request.set_method(Get)
+    |> request.set_host("test-api.service.hmrc.gov.uk")
+    |> request.set_path("/hello/world")
+    |> request.prepend_header("accept", "application/vnd.hmrc.1.0+json")
 
   assert Ok(resp) = httpc.send(req)
   assert 200 = resp.status
-  assert Ok("application/json") = http.get_resp_header(resp, "content-type")
+  assert Ok("application/json") = response.get_header(resp, "content-type")
   assert "{\"message\":\"Hello World\"}" = resp.body
 }
 
 pub fn get_request_discards_body_test() {
   let req =
-    http.default_req()
-    |> http.set_method(Get)
-    |> http.set_host("test-api.service.hmrc.gov.uk")
-    |> http.set_path("/hello/world")
-    |> http.set_req_body("This gets dropped")
-    |> http.prepend_req_header("accept", "application/vnd.hmrc.1.0+json")
+    request.new()
+    |> request.set_method(Get)
+    |> request.set_host("test-api.service.hmrc.gov.uk")
+    |> request.set_path("/hello/world")
+    |> request.set_body("This gets dropped")
+    |> request.prepend_header("accept", "application/vnd.hmrc.1.0+json")
 
   assert Ok(resp) = httpc.send(req)
   assert 200 = resp.status
-  assert Ok("application/json") = http.get_resp_header(resp, "content-type")
+  assert Ok("application/json") = response.get_header(resp, "content-type")
   assert "{\"message\":\"Hello World\"}" = resp.body
 }
 
 pub fn head_request_discards_body_test() {
   let req =
-    http.default_req()
-    |> http.set_method(Head)
-    |> http.set_host("postman-echo.com")
-    |> http.set_path("/get")
-    |> http.set_req_body("This gets dropped")
+    request.new()
+    |> request.set_method(Head)
+    |> request.set_host("postman-echo.com")
+    |> request.set_path("/get")
+    |> request.set_body("This gets dropped")
 
   assert Ok(resp) = httpc.send(req)
   assert 200 = resp.status
   assert Ok("application/json; charset=utf-8") =
-    http.get_resp_header(resp, "content-type")
+    response.get_header(resp, "content-type")
   assert "" = resp.body
 }
 
 pub fn options_request_discards_body_test() {
   let req =
-    http.default_req()
-    |> http.set_method(Options)
-    |> http.set_host("postman-echo.com")
-    |> http.set_path("/get")
-    |> http.set_req_body("This gets dropped")
+    request.new()
+    |> request.set_method(Options)
+    |> request.set_host("postman-echo.com")
+    |> request.set_path("/get")
+    |> request.set_body("This gets dropped")
 
   assert Ok(resp) = httpc.send(req)
   assert 200 = resp.status
   assert Ok("text/html; charset=utf-8") =
-    http.get_resp_header(resp, "content-type")
+    response.get_header(resp, "content-type")
   assert "GET,HEAD,PUT,POST,DELETE,PATCH" = resp.body
 }


### PR DESCRIPTION
This updates the dependencies and code to be able to work with the Gleam http module 3.0. This will allow this library to more easily be used in other libraries that are expecting the 3.0 APIs