### PR TITLE
Fix README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ import gleam/httpc
 import gleam/result
 import gleeunit/should
 
-pub fn main() {
+pub fn send_request() {
   // Prepare a HTTP request record
   let assert Ok(req) =
     request.to("https://test-api.service.hmrc.gov.uk/hello/world")

--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ pub fn send_request() {
     request.to("https://test-api.service.hmrc.gov.uk/hello/world")
 
   let req =
-    base_req
-    |> request.prepend_header("accept", "application/vnd.hmrc.1.0+json")
+    request.prepend_header(base_req, "accept", "application/vnd.hmrc.1.0+json")
 
   // Send the HTTP request to the server
   use resp <- result.try(httpc.send(req))

--- a/README.md
+++ b/README.md
@@ -14,13 +14,12 @@ import gleeunit/should
 
 pub fn send_request() {
   // Prepare a HTTP request record
-  let assert Ok(req) =
+    let assert Ok(base_req) =
     request.to("https://test-api.service.hmrc.gov.uk/hello/world")
-    |> result.map(request.prepend_header(
-      _,
-      "accept",
-      "application/vnd.hmrc.1.0+json",
-    ))
+
+  let req =
+    base_req
+    |> request.prepend_header("accept", "application/vnd.hmrc.1.0+json")
 
   // Send the HTTP request to the server
   use resp <- result.try(httpc.send(req))

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ import gleeunit/should
 
 pub fn send_request() {
   // Prepare a HTTP request record
-    let assert Ok(base_req) =
+  let assert Ok(base_req) =
     request.to("https://test-api.service.hmrc.gov.uk/hello/world")
 
   let req =

--- a/README.md
+++ b/README.md
@@ -6,17 +6,21 @@
 Bindings to Erlang's built in HTTP client, `httpc`.
 
 ```gleam
-import gleam/httpc
-import gleam/http.{Get}
 import gleam/http/request
 import gleam/http/response
+import gleam/httpc
 import gleam/result
 import gleeunit/should
 
-pub fn send_request() {
+pub fn main() {
   // Prepare a HTTP request record
   let assert Ok(req) =
     request.to("https://test-api.service.hmrc.gov.uk/hello/world")
+    |> result.map(request.prepend_header(
+      _,
+      "accept",
+      "application/vnd.hmrc.1.0+json",
+    ))
 
   // Send the HTTP request to the server
   use resp <- result.try(httpc.send(req))


### PR DESCRIPTION
### Fixes
1. Removes unused `import gleam/http.{Get}`
2. Sorts remaining imports
3. Fixes 406  due to an Invalid Accept Header

Current code results in
```erl
exception error: {assertEqual,[{module,gleeunit_ffi},
                               {line,14},
                               {expression,"Actual"},
                               {expected,200},
                               {value,406}]}
  in function  gleeunit_ffi:should_equal/2 (/user/gleam/example/build/dev/erlang/gleeunit/_gleam_artefacts/gleeunit_ffi.erl, line 14)
  in call from example:'-main/0-fun-0-'/1 (/user/gleam/example/build/dev/erlang/example/_gleam_artefacts/example, line 26)
```

Unfortunately, this complicates the example again. An alternative might be using another example service.

—
On a related note, 2.2.0 seems to already be released to Hex, GitHub indicates a 2.1.2  release as the latest.