### PR TITLE
test: fix `gleam_httpc_test.ipv6_test`

### DIFF
--- a/test/gleam_httpc_test.gleam
+++ b/test/gleam_httpc_test.gleam
@@ -95,7 +95,7 @@ pub fn invalid_tls_test() {
 
 pub fn ipv6_test() {
   // This URL is ipv6 only
-  let assert Ok(req) = request.to("https://ipv6.google.com")
+  let assert Ok(req) = request.to("https://ipv6test.google.com")
   let assert Ok(resp) = httpc.send(req)
   let assert 200 = resp.status
 }


### PR DESCRIPTION
```
  1) gleam_httpc_test.ipv6_test
     #{function => <<"ipv6_test">>,line => 99,
       message => <<"Assertion pattern match failed">>,
       module => <<"gleam_httpc_test">>,
       value =>
           {error,{failed_to_connect,{posix,<<"nxdomain">>},
                                     {posix,<<"enetunreach">>}}},
       gleam_error => let_assert}
     location: gleam_httpc_test.ipv6_test:99
     stacktrace:
       gleam_httpc_test.ipv6_test
     output: 

Finished in 3.240 seconds
9 tests, 1 failures
```

Example: https://github.com/gleam-lang/httpc/actions/runs/11917211450/job/33211719847

Let's try this approach.