### PR TITLE
fix google url for ipv6 test

### DIFF
--- a/test/gleam_httpc_test.gleam
+++ b/test/gleam_httpc_test.gleam
@@ -95,7 +95,7 @@ pub fn invalid_tls_test() {
 
 pub fn ipv6_test() {
   // This URL is ipv6 only
-  let assert Ok(req) = request.to("https://ipv6.google.com")
+  let assert Ok(req) = request.to("https://ipv6test.google.com")
   let assert Ok(resp) = httpc.send(req)
   let assert 200 = resp.status
 }


### PR DESCRIPTION
The google url used previously for the ipv6 test seems to be gone now. There's this other one, which makes the test pass although to be honest I don't know if that necessarily means the request is being made with ipv6.